### PR TITLE
Update intro text to Vanta

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@
 # Site settings
 title: Gae Blog
 subtitle: Notes, Word Salad, etc.
-brief-intro: "Senior Software Engineer at Stubhub"
+brief-intro: "Senior Software Engineer at Vanta"
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "https://www.gaeblog.com" # the base hostname & protocol for your site
 
@@ -87,7 +87,7 @@ analytics:
 author:
   name: "Yanxi Chen"
   avatar: "/assets/avatar1.jpeg"
-  bio: "Senior Software Engineer at Stubhub" # Note: Markdown is allowed
+  bio: "Senior Software Engineer at Vanta" # Note: Markdown is allowed
   location: "California, USA"
   links:
     - label: "GitHub"


### PR DESCRIPTION
### Motivation
- Bring the site profile text up to date to reflect the current role at Vanta instead of Stubhub.
- Keep the brief intro and author bio consistent across the site configuration.

### Description
- Updated `brief-intro` in `_config.yml` from "Senior Software Engineer at Stubhub" to "Senior Software Engineer at Vanta".
- Updated `author.bio` in `_config.yml` from "Senior Software Engineer at Stubhub" to "Senior Software Engineer at Vanta".

### Testing
- Ran `rg -n "brief-intro|bio:|Stubhub|Vanta" _config.yml` to verify the two profile fields now contain `Vanta` and no remaining `Stubhub`, which succeeded.
- Printed the top of `_config.yml` with `nl -ba _config.yml | sed -n '1,120p'` to confirm the updated lines display correctly, which succeeded.
- Attempted `bundle exec jekyll serve --host 0.0.0.0 --port 4000` to perform a local visual check, which failed because the `jekyll`/Bundler executables are not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699cc6eedb6c832f90282f22be7699b5)